### PR TITLE
Replay important events

### DIFF
--- a/backend/src/main/scala/akka/viz/events/EventPublisherActor.scala
+++ b/backend/src/main/scala/akka/viz/events/EventPublisherActor.scala
@@ -1,7 +1,7 @@
 package akka.viz.events
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Terminated}
-import akka.viz.events.types.{AvailableMessageTypes, BackendEvent, Received, ReceivedWithId}
+import akka.viz.events.types._
 
 import scala.collection.immutable
 
@@ -10,8 +10,9 @@ class EventPublisherActor extends Actor with ActorLogging {
   var subscribers = immutable.Set[ActorRef]()
   var availableTypes = immutable.Set[Class[_ <: Any]]()
   var eventCounter = 0L
+  var replayables: Vector[ReplayableEvent] = Vector.empty
 
-  override def receive: Receive = {
+  override def receive = storeIfReplayable andThen {
     case r: Received =>
       trackMsgType(r.message)
       broadcast(ReceivedWithId(nextEventNumber(), r.sender, r.receiver, r.message))
@@ -24,6 +25,7 @@ class EventPublisherActor extends Actor with ActorLogging {
       subscribers += s
       context.watch(s)
       s ! AvailableMessageTypes(availableTypes.toList)
+      replayables.foreach(s ! _)
 
     case EventPublisherActor.Unsubscribe =>
       unsubscribe(sender())
@@ -34,6 +36,13 @@ class EventPublisherActor extends Actor with ActorLogging {
 
   def broadcast(backendEvent: BackendEvent): Unit = {
     subscribers.foreach(_ ! backendEvent)
+  }
+
+  def storeIfReplayable: PartialFunction[Any, Any] = {
+    case r: ReplayableEvent =>
+      replayables = replayables :+ r
+      r
+    case other => other
   }
 
   @inline

--- a/backend/src/main/scala/akka/viz/events/types/package.scala
+++ b/backend/src/main/scala/akka/viz/events/types/package.scala
@@ -10,15 +10,17 @@ package object types {
 
   sealed trait BackendEvent
 
+  sealed trait ReplayableEvent
+
   case class Received(sender: ActorRef, receiver: ActorRef, message: Any) extends InternalEvent
 
   case class ReceivedWithId(eventId: Long, sender: ActorRef, receiver: ActorRef, message: Any) extends BackendEvent
 
-  case class Spawned(ref: ActorRef, parent: ActorRef) extends InternalEvent with BackendEvent
+  case class Spawned(ref: ActorRef, parent: ActorRef) extends InternalEvent with BackendEvent with ReplayableEvent
 
   case class MailboxStatus(owner: ActorRef, size: Int) extends InternalEvent with BackendEvent
 
-  case class Instantiated(actorRef: ActorRef, actor: Actor) extends InternalEvent with BackendEvent
+  case class Instantiated(actorRef: ActorRef, actor: Actor) extends InternalEvent with BackendEvent with ReplayableEvent
 
   case class AvailableMessageTypes(classes: List[Class[_ <: Any]]) extends BackendEvent
 
@@ -32,8 +34,8 @@ package object types {
 
   case class CurrentActorState(actorRef: ActorRef, actor: Actor) extends InternalEvent with BackendEvent
 
-  case class ReceiveDelaySet(duration: Duration) extends InternalEvent with BackendEvent
+  case class ReceiveDelaySet(duration: Duration) extends InternalEvent with BackendEvent with ReplayableEvent
 
-  case class Killed(actorRef: ActorRef) extends InternalEvent with BackendEvent
+  case class Killed(actorRef: ActorRef) extends InternalEvent with BackendEvent with ReplayableEvent
 
 }

--- a/backend/src/test/scala/akka/viz/serialization/ReplayablesTest.scala
+++ b/backend/src/test/scala/akka/viz/serialization/ReplayablesTest.scala
@@ -1,0 +1,38 @@
+package akka.viz.serialization
+
+import akka.actor.{ActorSystem, Actor, ActorRef}
+import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.stream.scaladsl.{Sink, Source}
+import akka.viz.config.Config
+import akka.viz.events.EventSystem
+import akka.viz.events.types._
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FlatSpec, Matchers}
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+class ReplayablesTest extends FlatSpec with Matchers with ScalaFutures {
+  "EventSystem" should "store and replay important events" in {
+    val system: ActorSystem = ActorSystem(Config.internalSystemName)
+    implicit val materializer = ActorMaterializer()(system)
+
+    val replayables: Vector[InternalEvent] = Vector(
+      Spawned(ActorRef.noSender, null),
+      Instantiated(ActorRef.noSender, null))
+
+    replayables foreach EventSystem.publish
+
+    val fold: Sink[BackendEvent, Future[Vector[BackendEvent]]] = Sink.fold(Vector.empty[BackendEvent])(_ :+ _)
+
+    val future = Source.actorRef(200, OverflowStrategy.fail)
+      .mapMaterializedValue(EventSystem.subscribe)
+      .takeWithin(2.seconds)
+      .toMat(fold) {case (_, m) => m}.run()
+
+    whenReady(future, Timeout(3.seconds)) { result =>
+      result should contain allElementsOf replayables
+    }
+
+  }
+}


### PR DESCRIPTION
All actors since start of monitoring now appear on new client's graph, but the edges on js graph appear only after another event is broadcast; I figure there should be some distinction between `child-of` and `received-from` relationships (also on the graph I guess), then it'd be possible to reconstruct those on new client's graph. I refrained from storing `Received` due to memory conservation reasons.