### PR TITLE
Lightweight snapshots 

### DIFF
--- a/backend/src/main/resources/web/js/init.js
+++ b/backend/src/main/resources/web/js/init.js
@@ -29,6 +29,7 @@
     graphics.node(function (node) {
         var ui = Viva.Graph.svg('g');
         var svgText = Viva.Graph.svg('text').attr('y', '-4px').text(node.id);
+        if (!node.data) node.data = {}; // fixme refactor scala code to ensure this is created
         var imgLink = node.data.dead ? '/img/dead_actor.png' : '/img/actor.png'
         var img = Viva.Graph.svg('image')
                 .attr('width', nodeSize)

--- a/backend/src/main/scala/akka/viz/events/EventPublisherActor.scala
+++ b/backend/src/main/scala/akka/viz/events/EventPublisherActor.scala
@@ -4,14 +4,17 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Terminated}
 import akka.viz.events.types._
 
 import scala.collection.immutable
+import scala.collection.immutable.Queue
 
 class EventPublisherActor extends Actor with ActorLogging {
 
   var subscribers = immutable.Set[ActorRef]()
   var availableTypes = immutable.Set[Class[_ <: Any]]()
   var eventCounter = 0L
+  var snapshot: LightSnapshot = LightSnapshot()
+  var snapshotQueue = immutable.Queue.empty[InternalEvent]
 
-  override def receive: Receive = {
+  override def receive = collectForSnapshot andThen {
     case r: Received =>
       trackMsgType(r.message)
       broadcast(ReceivedWithId(nextEventNumber(), r.sender, r.receiver, r.message))
@@ -25,6 +28,8 @@ class EventPublisherActor extends Actor with ActorLogging {
       context.watch(s)
       s ! (if (EventSystem.isEnabled()) ReportingEnabled else ReportingDisabled)
       s ! AvailableMessageTypes(availableTypes.toList)
+      s ! SnapshotAvailable(snapshot)
+      snapshotQueue.foreach(s ! _)
 
     case EventPublisherActor.Unsubscribe =>
       unsubscribe(sender())
@@ -35,6 +40,18 @@ class EventPublisherActor extends Actor with ActorLogging {
 
   def broadcast(backendEvent: BackendEvent): Unit = {
     subscribers.foreach(_ ! backendEvent)
+  }
+
+  def collectForSnapshot: PartialFunction[Any, Any] = {
+    case ev: InternalEvent if snapshotQueue.size == EventPublisherActor.EventsForSnaphot =>
+      snapshot = snapshotQueue.enqueue(ev).foldLeft(snapshot) {
+        _.update(_)
+      }
+      snapshotQueue = Queue.empty
+      ev
+    case ev: InternalEvent =>
+      snapshotQueue = snapshotQueue.enqueue(ev)
+      ev
   }
 
   @inline
@@ -60,5 +77,7 @@ object EventPublisherActor {
   case object Subscribe
 
   case object Unsubscribe
+
+  val EventsForSnaphot = 200
 
 }

--- a/backend/src/main/scala/akka/viz/events/LightSnapshot.scala
+++ b/backend/src/main/scala/akka/viz/events/LightSnapshot.scala
@@ -1,0 +1,38 @@
+package akka.viz.events
+
+import akka.actor.ActorRef
+import akka.viz.events.types._
+import Predef.{any2stringadd => _, _}
+import scala.language.implicitConversions
+
+case class LightSnapshot(
+  liveActors: Set[String] = Set(),
+    children: Map[String, Set[String]] = Map(),
+    receivedFrom: Set[(String, String)] = Set()) {
+
+  implicit def ref2String(r: ActorRef): String = r.toString()
+  implicit def refPair2StringPair(pair: (ActorRef, ActorRef)): (String, String) = (pair._1.toString(), pair._2.toString())
+
+  def dead: Set[String] = {
+    liveActors diff (children.values.flatten ++ receivedFrom.flatMap(p => Seq(p._1, p._2))).toSet
+  }
+
+  def update(ev: InternalEvent): LightSnapshot = ev match {
+    case Received(from, to, _) =>
+      val live = liveActors ++ Seq[String](from, to)
+      val recv = receivedFrom + (from -> to)
+      copy(liveActors = live, receivedFrom = recv)
+    case Spawned(ref, parent) =>
+      val live = liveActors + ref
+      val childr = children.updated(parent, children.getOrElse(parent, Set()) + ref)
+      copy(liveActors = live, children = childr)
+    case Killed(ref) =>
+      copy(liveActors = liveActors - ref)
+    case CurrentActorState(ref, _) =>
+      copy(liveActors = liveActors + ref)
+    case Instantiated(ref, _) =>
+      copy(liveActors = liveActors + ref)
+    case other =>
+      this
+  }
+}

--- a/backend/src/main/scala/akka/viz/events/LightSnapshot.scala
+++ b/backend/src/main/scala/akka/viz/events/LightSnapshot.scala
@@ -6,9 +6,10 @@ import Predef.{any2stringadd => _, _}
 import scala.language.implicitConversions
 
 case class LightSnapshot(
-  liveActors: Set[String] = Set(),
+    liveActors: Set[String] = Set(),
     children: Map[String, Set[String]] = Map(),
-    receivedFrom: Set[(String, String)] = Set()) {
+    receivedFrom: Set[(String, String)] = Set()
+) {
 
   implicit def ref2String(r: ActorRef): String = r.path.toSerializationFormat
   implicit def refPair2StringPair(pair: (ActorRef, ActorRef)): (String, String) = (ref2String(pair._1), ref2String(pair._2))

--- a/backend/src/main/scala/akka/viz/events/LightSnapshot.scala
+++ b/backend/src/main/scala/akka/viz/events/LightSnapshot.scala
@@ -10,15 +10,15 @@ case class LightSnapshot(
     children: Map[String, Set[String]] = Map(),
     receivedFrom: Set[(String, String)] = Set()) {
 
-  implicit def ref2String(r: ActorRef): String = r.toString()
-  implicit def refPair2StringPair(pair: (ActorRef, ActorRef)): (String, String) = (pair._1.toString(), pair._2.toString())
+  implicit def ref2String(r: ActorRef): String = r.path.toSerializationFormat
+  implicit def refPair2StringPair(pair: (ActorRef, ActorRef)): (String, String) = (ref2String(pair._1), ref2String(pair._2))
 
   def dead: Set[String] = {
     liveActors diff (children.values.flatten ++ receivedFrom.flatMap(p => Seq(p._1, p._2))).toSet
   }
 
-  def update(ev: InternalEvent): LightSnapshot = ev match {
-    case Received(from, to, _) =>
+  def update(ev: BackendEvent): LightSnapshot = ev match {
+    case ReceivedWithId(_, from, to, _) =>
       val live = liveActors ++ Seq[String](from, to)
       val recv = receivedFrom + (from -> to)
       copy(liveActors = live, receivedFrom = recv)

--- a/backend/src/main/scala/akka/viz/events/types/package.scala
+++ b/backend/src/main/scala/akka/viz/events/types/package.scala
@@ -40,4 +40,6 @@ package object types {
 
   case object ReportingDisabled extends InternalEvent with BackendEvent
 
+  case class SnapshotAvailable(snapshot: LightSnapshot) extends BackendEvent
+
 }

--- a/backend/src/main/scala/akka/viz/server/Webservice.scala
+++ b/backend/src/main/scala/akka/viz/server/Webservice.scala
@@ -119,6 +119,8 @@ class Webservice(implicit fm: Materializer, system: ActorSystem) {
       protocol.ReportingDisabled
     case ReportingEnabled =>
       protocol.ReportingEnabled
+    case SnapshotAvailable(s) =>
+      protocol.SnapshotAvailable(s.liveActors.toList, s.dead.toList, s.children, s.receivedFrom)
   }
 
   def eventSerialization: Flow[protocol.ApiServerMessage, String, Any] = Flow[protocol.ApiServerMessage].map {

--- a/frontend/src/main/scala/akka/viz/frontend/FrontendApp.scala
+++ b/frontend/src/main/scala/akka/viz/frontend/FrontendApp.scala
@@ -8,7 +8,7 @@ import rx._
 import scala.collection.mutable
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExport
-import scala.scalajs.js.{ThisFunction0, JSApp, JSON}
+import scala.scalajs.js.{Dictionary, ThisFunction0, JSApp, JSON}
 import scala.util.Try
 import scalatags.JsDom.all._
 import upickle.default._
@@ -75,6 +75,14 @@ object FrontendApp extends JSApp with Persistence
 
       case Killed(ref) =>
         deadActors += actorName(ref)
+        seenActors.recalc()
+
+      case SnapshotAvailable(live, dead, childrenOf, rcv) =>
+        addActorsToSeen(live.map(actorName) : _*)
+        deadActors ++= dead.map(actorName)
+        for {
+          (from, to) <- rcv
+        } ensureGraphLink(actorName(from), actorName(to))
         seenActors.recalc()
 
       case Ping => {}

--- a/shared/src/main/scala/akka/viz/protocol/package.scala
+++ b/shared/src/main/scala/akka/viz/protocol/package.scala
@@ -1,6 +1,6 @@
 package akka.viz
 
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 package object protocol {
 

--- a/shared/src/main/scala/akka/viz/protocol/package.scala
+++ b/shared/src/main/scala/akka/viz/protocol/package.scala
@@ -40,6 +40,8 @@ package object protocol {
 
   case object Ping extends ApiServerMessage
 
+  case class SnapshotAvailable(live: List[String], dead: List[String], children: Map[String, Set[String]], receivedFrom: Set[(String, String)]) extends ApiServerMessage
+
   sealed trait ApiClientMessage
 
   case class SetAllowedMessages(allowedClasses: List[String]) extends ApiClientMessage


### PR DESCRIPTION
Added a lightweight snapshot sent to new subscribers with a list of live/dead actorRefs plus `child-of` and `received-from` relationships