### PR TITLE
tweak force-directed graph parameters and hide not connected yet

### DIFF
--- a/frontend/src/main/scala/akkaviz/frontend/components/MonitoringOnOff.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/MonitoringOnOff.scala
@@ -1,19 +1,12 @@
 package akkaviz.frontend.components
 
-import akkaviz.frontend.PrettyJson
-import org.scalajs.dom
-import org.scalajs.dom.html.{Option => DomOption, _}
-import org.scalajs.dom.{Element => domElement, Event}
-import rx.{Ctx, Rx, Var}
+import org.scalajs.dom.html._
+import org.scalajs.dom.Event
+import rx.{Ctx, Var}
 
 import scalatags.JsDom.all._
 
-class OnOffPanel(status: Var[MonitoringStatus])(implicit ctx: Ctx.Owner) extends Component with PrettyJson {
-
-  lazy val messagePanelTitle = div(cls := "panel-heading", id := "messagespaneltitle", "Toggle reporting").render
-
-  lazy val lbl = span().render
-  lazy val inp = input(tpe := "checkbox").render
+class MonitoringOnOff(status: Var[MonitoringStatus])(implicit ctx: Ctx.Owner) extends Component with OnOffWithLabel {
 
   inp.onchange = (d: Event) => {
     status() = Awaiting(Synced(inp.checked))
@@ -36,12 +29,6 @@ class OnOffPanel(status: Var[MonitoringStatus])(implicit ctx: Ctx.Owner) extends
 
   }
 
-  lazy val stateBtn = div(
-    `class` := "togglebutton",
-    label(
-      inp, lbl
-    )
-  )
 
   override def render: Element = {
     Seq(

--- a/frontend/src/main/scala/akkaviz/frontend/components/UnconnectedOnOff.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/UnconnectedOnOff.scala
@@ -1,0 +1,14 @@
+package akkaviz.frontend.components
+
+import org.scalajs.dom.Event
+import org.scalajs.dom.html.Element
+import rx.Var
+
+
+class UnconnectedOnOff(status: Var[Boolean]) extends OnOffWithLabel with Component {
+  lbl.innerHTML = "Show actors without any connections on graph"
+  inp.onchange = { e: Event =>
+    status() = inp.checked
+  }
+  override def render: Element = stateBtn.render
+}

--- a/frontend/src/main/scala/akkaviz/frontend/components/components.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/components.scala
@@ -19,6 +19,20 @@ trait Component {
   def render: Element
 }
 
+
+trait OnOffWithLabel {
+  lazy val lbl = span().render
+  lazy val inp = input(tpe := "checkbox").render
+
+
+  lazy val stateBtn = div(
+    `class` := "togglebutton",
+    label(
+      inp, lbl
+    )
+  )
+}
+
 class ActorSelector(
     seenActors: Var[Set[String]],
     selectedActors: Var[Set[String]],

--- a/monitoring/src/main/resources/web/index.html
+++ b/monitoring/src/main/resources/web/index.html
@@ -37,6 +37,7 @@
         <div class="tab-pane fade panel panel-default" id="messagefiltering"></div>
         <div class="tab-pane fade panel panel-default" id="globalsettings">
             <div id="onoffsettings" class="panel panel-default"></div>
+            <div class="panel panel-default"><div id="graphsettings" class="panel-body"></div></div>
             <div id="receivedelay" class="panel panel-default"></div>
         </div>
     </div>

--- a/monitoring/src/main/resources/web/js/init.js
+++ b/monitoring/src/main/resources/web/js/init.js
@@ -1,6 +1,6 @@
 
     function frontendApp() {
-        return akka.viz.frontend.FrontendApp()
+        return akkaviz.frontend.FrontendApp()
     }
 
     var graph = Viva.Graph.graph();

--- a/monitoring/src/main/resources/web/js/init.js
+++ b/monitoring/src/main/resources/web/js/init.js
@@ -6,12 +6,13 @@
     var graph = Viva.Graph.graph();
 
     var nodeSize = 40;
-    var idealLength = 5 * nodeSize;
+    var idealLength = 5.5 * nodeSize;
     var layout = Viva.Graph.Layout.forceDirected(graph, {
         springLength: idealLength,
-        springCoeff: 0.0008,
-        dragCoeff: 0.02,
-        gravity: -1.2
+        springCoeff: 0.001,
+        dragCoeff: 0.09,
+        gravity: -2.5,
+        stableThreshold: 0.1
     });
 
     var graphics = Viva.Graph.View.svgGraphics();


### PR DESCRIPTION
Force-directed graph layout parameters caused jelly-like and annoying behavior. Tweaked and addded a toggle to hide nodes not connected yet in global settings.