### PR TITLE
Tabbed info

### DIFF
--- a/frontend/src/main/scala/akkaviz/frontend/FrontendUtil.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/FrontendUtil.scala
@@ -31,14 +31,6 @@ object FrontendUtil {
   }
 
   @inline
-  def actorComponent(actorRef: String): Element = {
-    def isUser(ref: String): Boolean = ref.contains("user")
-    span(
-      "data-toggle".attr := "tooltip", "data-placement".attr := "top", title := actorRef, shortActorName(actorRef)
-    ).render
-  }
-
-  @inline
   def shortActorName(actorRef: String) = actorRef.split('/').drop(3).mkString("/")
 
   @inline

--- a/frontend/src/main/scala/akkaviz/frontend/components/ActorSelector.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/ActorSelector.scala
@@ -1,9 +1,7 @@
 package akkaviz.frontend.components
 
 import akkaviz.frontend.ActorRepository.ActorState
-import akkaviz.frontend.FrontendUtil.actorComponent
-import akkaviz.frontend.{DOMGlobalScope, PrettyJson}
-import akkaviz.protocol
+import akkaviz.frontend.{FrontendUtil, DOMGlobalScope, PrettyJson}
 import akkaviz.protocol.ActorFailure
 import org.scalajs.dom.html._
 import org.scalajs.dom.{Element => domElement, Node, console, document}
@@ -44,24 +42,6 @@ class ActorSelector(
 
     parent.appendChild(elem)
   }
-
-  private[this] val popoverContent: ThisFunction0[domElement, Node] = (that: domElement) => {
-    val actor: String = that.getAttribute("data-actor")
-    val content = div().render
-    val stateVar = currentActorState(actor)
-    //renderActorState(content, stateVar) //fixme!
-    Seq[Frag](
-      h5(actor),
-      content
-    ).render
-  }
-
-  private[this] val popoverOptions = js.Dictionary(
-    "content" -> popoverContent,
-    "trigger" -> "hover",
-    "placement" -> "right",
-    "html" -> true
-  )
 
   private[this] def failureTable(failures: Seq[ActorFailure]) =
     table(
@@ -131,12 +111,11 @@ class ActorSelector(
               () => toggleActor(actorRef)
             })),
           td(
-            actorComponent(actorRef),
-            span(float.right, actorExceptionsIndicator(actorRef, actorFailures.now.filter(_.actorRef == actorRef)), refreshButton(actorRef), detailsButton(actorRef))
+            span(FrontendUtil.shortActorName(actorName)),
+            span(float.right, actorExceptionsIndicator(actorName, actorFailures.now.filter(_.actorRef == actorName)), detailsButton(actorName))
           )
         )(data("actor") := actorRef).render
 
-        DOMGlobalScope.$(element).popover(popoverOptions)
         element
     }
 

--- a/frontend/src/main/scala/akkaviz/frontend/components/ActorSelector.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/ActorSelector.scala
@@ -96,11 +96,11 @@ class ActorSelector(
         val stateVar = currentActorState(actorName)
 
         new ActorStateTab(stateVar).attach(document.querySelector("#right-pane"))
-//
-//        fsmGraph.foreach {
-//          fsmGraph =>
-//            fsmGraph.displayFsm(stateVar.now.fsmTransitions)
-//        }
+
+        fsmGraph.foreach {
+          fsmGraph =>
+            fsmGraph.displayFsm(stateVar.now.fsmTransitions)
+        }
       }
     )
 

--- a/frontend/src/main/scala/akkaviz/frontend/components/ActorSelector.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/ActorSelector.scala
@@ -49,35 +49,11 @@ class ActorSelector(
     val actor: String = that.getAttribute("data-actor")
     val content = div().render
     val stateVar = currentActorState(actor)
-    renderActorState(content, stateVar)
+    //renderActorState(content, stateVar) //fixme!
     Seq[Frag](
       h5(actor),
       content
     ).render
-  }
-
-  private[this] def renderActorState(element: domElement, stateVar: Var[ActorState]): Unit = {
-    stateVar.foreach {
-      state =>
-        val renderedState = Seq[Frag](
-          div(strong("Class: "), state.className.getOrElse[String]("Unknown class")),
-          div(strong("Is dead: "), state.isDead.toString),
-          div(strong("Internal state: "), pre(state.internalState.map(prettyPrintJson).getOrElse[String]("Internal state unknown"))),
-          div(strong("Is FSM: "), state.fsmState.isDefined.toString),
-          state.fsmState.map[Frag] {
-            fsm =>
-              Seq(
-                div(strong("FSM State: "), pre(prettyPrintJson(fsm.currentState))),
-                div(strong("FSM Data: "), pre(prettyPrintJson(fsm.currentData)))
-              )
-          }.getOrElse(()),
-          div(strong("Mailbox size: "), state.mailboxSize.map(_.toString).getOrElse[String]("Unknown")),
-          div(strong("Last updated: "), state.lastUpdatedAt.toISOString())
-        ).render
-
-        element.innerHTML = ""
-        element.appendChild(renderedState)
-    }
   }
 
   private[this] val popoverOptions = js.Dictionary(
@@ -115,17 +91,16 @@ class ActorSelector(
 
   private[this] def detailsButton(actorRef: String) =
     span(
-      `class` := "imgbtn glyphicon glyphicon-info-sign",
-      "data-toggle".attr := "modal",
-      "data-target".attr := "#details-modal",
+      `class` := "glyphicon glyphicon-info-sign",
       onclick := { () =>
-        val details = document.getElementById("actor-details")
-        val stateVar = currentActorState(actorRef)
-        renderActorState(details, stateVar)
-        fsmGraph.foreach {
-          fsmGraph =>
-            fsmGraph.displayFsm(stateVar.now.fsmTransitions)
-        }
+        val stateVar = currentActorState(actorName)
+
+        new ActorStateTab(stateVar).attach(document.querySelector("#right-pane"))
+//
+//        fsmGraph.foreach {
+//          fsmGraph =>
+//            fsmGraph.displayFsm(stateVar.now.fsmTransitions)
+//        }
       }
     )
 

--- a/frontend/src/main/scala/akkaviz/frontend/components/MessagesPanel.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/MessagesPanel.scala
@@ -1,6 +1,6 @@
 package akkaviz.frontend.components
 
-import akkaviz.frontend.FrontendUtil.actorComponent
+import akkaviz.frontend.FrontendUtil.shortActorName
 import akkaviz.frontend.{FrontendUtil, PrettyJson}
 import akkaviz.protocol.Received
 import org.scalajs.dom.html._
@@ -84,8 +84,8 @@ class MessagesPanel(selectedActors: Var[Set[String]]) extends Component with Pre
     tr(
       "data-message".attr := rcv.payload.getOrElse(""),
       `class` := "tgl",
-      td(actorComponent(rcv.sender)),
-      td(actorComponent(rcv.receiver)),
+      td(shortActorName(rcv.sender)),
+      td(shortActorName(rcv.receiver)),
       td(rcv.payloadClass, if (!rcv.handled) unhandledIndicator else ""),
       onclick := toggleMessageDetails
     )

--- a/frontend/src/main/scala/akkaviz/frontend/components/tabs.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/tabs.scala
@@ -1,0 +1,72 @@
+package akkaviz.frontend.components
+
+import akkaviz.frontend.ActorRepository.ActorState
+import org.scalajs.dom.{Element => domElement}
+import rx.Var
+
+import scalatags.JsDom.all._
+
+trait ClosableTab extends Tab {
+  def onClose(): Unit = {
+    tab.parentNode.removeChild(tab)
+    tabBody.parentNode.removeChild(tabBody)
+  }
+
+  override def attach(tabbedPane: domElement): Unit = {
+    super.attach(tabbedPane)
+    tab.appendChild(a(cls:="glyphicon glyphicon-remove", href:="#", float.left, onclick := onClose _).render)
+  }
+}
+
+trait Tab extends Component {
+  def name: String
+
+  def tabId: String
+
+  lazy val tab = li(a(href:=s"#$tabId", "data-toggle".attr:="tab", s"$name", float.left)).render
+
+  lazy val tabBody = div(`class`:="tab-pane panel panel-default ", id:=s"$tabId").render
+
+  override def attach(tabbedPane: domElement): Unit = {
+    tabbedPane.querySelector("ul.nav-tabs").appendChild(tab)
+    tabbedPane.querySelector("div.tab-content").appendChild(tabBody)
+  }
+
+}
+
+class ActorStateTab(actorState: Var[ActorState]) extends ClosableTab {
+  import akkaviz.frontend.PrettyJson._
+
+  val name = actorState.now.path
+  val tabId = s"actor-state-${actorState.now.path.replace("/", "-").filterNot(_ == ':')}"
+  val stateObs = actorState.foreach(renderState(_))
+
+  def renderState(state: ActorState) = {
+    val rendered = div(cls := "panel-body",
+      div(strong("Class: "), state.className.getOrElse[String]("Unknown class")),
+      div(strong("Is dead: "), state.isDead.toString),
+      div(strong("Internal state: "), pre(state.internalState.map(prettyPrintJson).getOrElse[String]("Internal state unknown"))),
+      div(strong("Is FSM: "), state.fsmState.isDefined.toString),
+      state.fsmState.map[Frag] {
+        fsm =>
+          Seq(
+            div(strong("FSM State: "), pre(prettyPrintJson(fsm.currentState))),
+            div(strong("FSM Data: "), pre(prettyPrintJson(fsm.currentData)))
+          )
+      }.getOrElse(()),
+      div(strong("Mailbox size: "), state.mailboxSize.map(_.toString).getOrElse[String]("Unknown")),
+      div(strong("Last updated: "), state.lastUpdatedAt.toISOString())
+    ).render
+
+    tabBody.innerHTML = ""
+    tabBody.appendChild(rendered)
+  }
+
+
+  override def onClose() = {
+    super.onClose()
+    stateObs.kill()
+  }
+
+}
+

--- a/frontend/src/main/scala/akkaviz/frontend/components/tabs.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/tabs.scala
@@ -15,7 +15,7 @@ trait ClosableTab extends Tab {
 
   override def attach(tabbedPane: domElement): Unit = {
     super.attach(tabbedPane)
-    tab.appendChild(a(cls:="glyphicon glyphicon-remove", href:="#", float.left, onclick := onClose _).render)
+    tab.appendChild(a(cls := "glyphicon glyphicon-remove", href := "#", float.left, onclick := onClose _).render)
   }
 }
 
@@ -27,7 +27,7 @@ trait Tab extends Component {
   lazy val activateA = a(href := s"#$tabId", "data-toggle".attr := "tab", s"$name", float.left).render
   lazy val tab = li(activateA).render
 
-  lazy val tabBody = div(`class`:="tab-pane panel panel-default ", id:=s"$tabId").render
+  lazy val tabBody = div(`class` := "tab-pane panel panel-default ", id := s"$tabId").render
 
   override def attach(tabbedPane: domElement): Unit = {
     tabbedPane.querySelector("ul.nav-tabs").appendChild(tab)
@@ -47,7 +47,8 @@ class ActorStateTab(actorState: Var[ActorState]) extends ClosableTab {
   val stateObs = actorState.foreach(renderState(_))
 
   def renderState(state: ActorState) = {
-    val rendered = div(cls := "panel-body",
+    val rendered = div(
+      cls := "panel-body",
       div(strong("Class: "), state.className.getOrElse[String]("Unknown class")),
       div(strong("Is dead: "), state.isDead.toString),
       div(strong("Internal state: "), pre(state.internalState.map(prettyPrintJson).getOrElse[String]("Internal state unknown"))),
@@ -66,7 +67,6 @@ class ActorStateTab(actorState: Var[ActorState]) extends ClosableTab {
     tabBody.innerHTML = ""
     tabBody.appendChild(rendered)
   }
-
 
   override def onClose() = {
     super.onClose()

--- a/monitoring/src/main/resources/web/css/style.css
+++ b/monitoring/src/main/resources/web/css/style.css
@@ -9,7 +9,7 @@ html {
     top: 0;
     overflow: hidden;
     height: 100%;
-    width: 100%;
+    right: 0;
 }
 
 #right-pane .tab-content {


### PR DESCRIPTION
doesn't switch to last active tab after closing the active one; lifecycle management coming up in next PR
also, fsm graph might be a little jumpy as it's re-rendered every time an update comes through, because of dom re-creation
