### PR TITLE
remove data from graph based on current date

### DIFF
--- a/frontend/src/main/scala/akkaviz/frontend/components/ThroughputGraphTab.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/ThroughputGraphTab.scala
@@ -84,7 +84,7 @@ class ThroughputGraphViewTab(implicit ctx: Ctx.Owner) extends Tab with FancyColo
     val interval = range.end.valueOf() - range.start.valueOf()
 
     val oldIds = items.getIds(literal(filter = { (item: Item) =>
-      item.x.valueOf() < (range.start.valueOf() - interval)
+      item.x.valueOf() < (Date.now() - interval - 2.seconds.toMillis)
     }))
     items.remove(oldIds)
   }

--- a/frontend/src/main/scala/akkaviz/frontend/components/ThroughputGraphTab.scala
+++ b/frontend/src/main/scala/akkaviz/frontend/components/ThroughputGraphTab.scala
@@ -31,6 +31,7 @@ class ThroughputGraphViewTab(implicit ctx: Ctx.Owner) extends Tab with FancyColo
     end = js.Date.now() - 1000,
     interpolation = false,
     drawPoints = false,
+    moveable = false,
     dataAxis = literal(
       showMinorLabels = false,
       left = literal(


### PR DESCRIPTION
Remove stored data client-side, based on current date instead of Graph2d `window.start`. Prevents excessive accumulation of data in Graph2d DataSet if the graph is not scrolling, i.e. when throughput tab is not active.